### PR TITLE
Manual typography and semantics changes for the play "Dead Dialogue"

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -101,35 +101,36 @@ p span.i15{
 	text-align: center;
 }
 
-/* "Dead Dialogue" styling, adapted from drama formatting */
-table{
+/* Drama styling */
+[epub|type~="z3998:drama"] table,
+table[epub|type~="z3998:drama"]{
 	border-collapse: collapse;
 	margin: 1em auto;
 	width: 100%;
 }
 
-tr:first-child td{
+[epub|type~="z3998:drama"] tr:first-child td{
 	padding-top: 0;
 }
 
-tr:last-child td{
+[epub|type~="z3998:drama"] tr:last-child td{
 	padding-bottom: 0;
 }
 
-td{
+[epub|type~="z3998:drama"] td{
 	padding: .5em;
 	vertical-align: top;
 }
 
-td:last-child{
+[epub|type~="z3998:drama"] td:last-child{
 	padding-right: 0;
 }
 
-td:first-child{
+[epub|type~="z3998:drama"] td:first-child{
 	padding-left: 0;
 }
 
-td[epub|type~="z3998:persona"]{
+[epub|type~="z3998:drama"] td[epub|type~="z3998:persona"]{
 	hyphens: none;
 	-epub-hyphens: none;
 	text-align: right;

--- a/src/epub/text/part-2.xhtml
+++ b/src/epub/text/part-2.xhtml
@@ -969,13 +969,13 @@
 					</p>
 				</section>
 			</article>
-			<article id="dead-dialogue" epub:type="z3998:poem">
+			<article id="dead-dialogue" epub:type="z3998:drama">
 				<h3 epub:type="title">Dead Dialogue</h3>
 				<table>
 					<tbody>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>I would now that the sweet light of the sun</span>
 									<br/>
@@ -987,7 +987,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Rejoice that now at least thou art done with life;</span>
 									<br/>
@@ -997,7 +997,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span class="i15">At last</span>
 									<br/>
@@ -1021,7 +1021,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">3rd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span><em>I</em> am not yet utterly putrified,</span>
 									<br/>
@@ -1039,7 +1039,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<span>I would that I might leave this place of ordure</span>
 								<br/>
 								<span>And look once more upon the face of the world,</span>
@@ -1049,7 +1049,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span class="i12">O foolish ragged-bones,</span>
 									<br/>
@@ -1063,7 +1063,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Envy me not, O stench, slop-face, dung-eyes;</span>
 									<br/>
@@ -1075,7 +1075,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Envy me not, thou, that I am so sweet</span>
 									<br/>
@@ -1087,7 +1087,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">4th Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Be silent, both ye dead and rotten things;</span>
 									<br/>
@@ -1101,7 +1101,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">3rd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Is it so sweet a thing, this love, this love?</span>
 								</p>
@@ -1109,7 +1109,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Thy lips are green for kissing, and streaks of black</span>
 									<br/>
@@ -1119,7 +1119,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">4th Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Ha, ha, I know wherefore thou speakest so:</span>
 									<br/>
@@ -1133,7 +1133,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>O beautiful, O dead, O spit upon,</span>
 									<br/>
@@ -1147,7 +1147,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Rotten one!</span>
 								</p>
@@ -1155,7 +1155,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span class="i5">Dung-heap!</span>
 								</p>
@@ -1163,7 +1163,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span class="i10">Dead one!</span>
 								</p>
@@ -1171,7 +1171,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span class="i15">Beast! beast! beast!</span>
 									<br/>
@@ -1181,7 +1181,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>They say that those thou lovedst were not men,</span>
 									<br/>
@@ -1191,7 +1191,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">4th Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Come, come, my brothers, be not so slanderous;</span>
 									<br/>
@@ -1201,7 +1201,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">3rd Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Thou sayest true, new brother.</span>
 								</p>
@@ -1209,7 +1209,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">1st Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span class="i15">Thou sayest true.</span>
 								</p>
@@ -1218,7 +1218,7 @@
 						<tr>
 							<td epub:type="z3998:persona">2nd Corpse<br/>
 							<i epub:type="z3998:stage-direction">Aside.</i></td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>I shall not suffer anything any more;</span>
 									<br/>
@@ -1234,7 +1234,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">5th Corpse</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Rejoice not thou, that thou art fallen</span>
 									<br/>
@@ -1246,7 +1246,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">Sepulchre</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Be silent, now, ye spindle-shankèd dead!</span>
 									<br/>
@@ -1270,7 +1270,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">A voice above singing</td>
-							<td>
+							<td epub:type="z3998:verse">
 								<p>
 									<span>Golden is the sunlight,</span>
 									<br/>

--- a/src/epub/text/part-2.xhtml
+++ b/src/epub/text/part-2.xhtml
@@ -974,7 +974,7 @@
 				<table>
 					<tbody>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span>I would now that the sweet light of the sun</span>
@@ -986,7 +986,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span>Rejoice that now at least thou art done with life;</span>
@@ -996,7 +996,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span class="i15">At last</span>
@@ -1020,7 +1020,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">3rd Corpse.</td>
+							<td epub:type="z3998:persona">3rd Corpse</td>
 							<td>
 								<p>
 									<span><em>I</em> am not yet utterly putrified,</span>
@@ -1038,7 +1038,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<span>I would that I might leave this place of ordure</span>
 								<br/>
@@ -1048,7 +1048,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span class="i12">O foolish ragged-bones,</span>
@@ -1062,7 +1062,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span>Envy me not, O stench, slop-face, dung-eyes;</span>
@@ -1074,7 +1074,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span>Envy me not, thou, that I am so sweet</span>
@@ -1086,7 +1086,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">4th Corpse.</td>
+							<td epub:type="z3998:persona">4th Corpse</td>
 							<td>
 								<p>
 									<span>Be silent, both ye dead and rotten things;</span>
@@ -1100,7 +1100,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">3rd Corpse.</td>
+							<td epub:type="z3998:persona">3rd Corpse</td>
 							<td>
 								<p>
 									<span>Is it so sweet a thing, this love, this love?</span>
@@ -1108,7 +1108,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span>Thy lips are green for kissing, and streaks of black</span>
@@ -1118,7 +1118,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">4th Corpse.</td>
+							<td epub:type="z3998:persona">4th Corpse</td>
 							<td>
 								<p>
 									<span>Ha, ha, I know wherefore thou speakest so:</span>
@@ -1132,7 +1132,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span>O beautiful, O dead, O spit upon,</span>
@@ -1146,7 +1146,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span>Rotten one!</span>
@@ -1154,7 +1154,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span class="i5">Dung-heap!</span>
@@ -1162,7 +1162,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span class="i10">Dead one!</span>
@@ -1170,7 +1170,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span class="i15">Beast! beast! beast!</span>
@@ -1180,7 +1180,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.</td>
+							<td epub:type="z3998:persona">2nd Corpse</td>
 							<td>
 								<p>
 									<span>They say that those thou lovedst were not men,</span>
@@ -1190,7 +1190,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">4th Corpse.</td>
+							<td epub:type="z3998:persona">4th Corpse</td>
 							<td>
 								<p>
 									<span>Come, come, my brothers, be not so slanderous;</span>
@@ -1200,7 +1200,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">3rd Corpse.</td>
+							<td epub:type="z3998:persona">3rd Corpse</td>
 							<td>
 								<p>
 									<span>Thou sayest true, new brother.</span>
@@ -1208,7 +1208,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">1st Corpse.</td>
+							<td epub:type="z3998:persona">1st Corpse</td>
 							<td>
 								<p>
 									<span class="i15">Thou sayest true.</span>
@@ -1216,7 +1216,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">2nd Corpse.<br/>
+							<td epub:type="z3998:persona">2nd Corpse<br/>
 							<i epub:type="z3998:stage-direction">Aside.</i></td>
 							<td>
 								<p>
@@ -1233,7 +1233,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">5th Corpse.</td>
+							<td epub:type="z3998:persona">5th Corpse</td>
 							<td>
 								<p>
 									<span>Rejoice not thou, that thou art fallen</span>
@@ -1245,7 +1245,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">Sepulchre.</td>
+							<td epub:type="z3998:persona">Sepulchre</td>
 							<td>
 								<p>
 									<span>Be silent, now, ye spindle-shankèd dead!</span>
@@ -1269,7 +1269,7 @@
 							</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">A voice above singing.</td>
+							<td epub:type="z3998:persona">A voice above singing</td>
 							<td>
 								<p>
 									<span>Golden is the sunlight,</span>


### PR DESCRIPTION
This PR focuses solely on the one play contained within this work, "Dead Dialogue." It's a complete, although very short, play written in verse.

The changes proposed here are as follows:

1. Remove ending punctuation from the table cells containing the speakers' names, [as per SEMoS §7.6.5.1](https://standardebooks.org/manual/1.8.2/7-high-level-structural-patterns#7.6.5.1);
2. Change the semantic inflection of the `<article>` element containing this play from `z3998:verse` to `z3998:drama`, [as per SEMoS §7.6.7.1](https://standardebooks.org/manual/1.8.2/7-high-level-structural-patterns#7.6.7.1);
3. Mark up the table rows containing the dramatic verse with the `z3998:verse` semantic inflection, [as per SEMoS §7.6.5.2.1](https://standardebooks.org/manual/1.8.2/7-high-level-structural-patterns#7.6.5.2.1); and
4. Update `local.css` with [the drama-specific CSS from SEMoS §7.6.4](https://standardebooks.org/manual/1.8.2/7-high-level-structural-patterns#7.6.4).