### PR TITLE
Add more semantics to indicate Latin-language text

### DIFF
--- a/src/epub/text/part-2.xhtml
+++ b/src/epub/text/part-2.xhtml
@@ -510,7 +510,7 @@
 				</p>
 			</article>
 			<article id="miserrimus" epub:type="z3998:poem">
-				<h3 epub:type="title">Miserrimus</h3>
+				<h3 epub:type="title" xml:lang="la">Miserrimus</h3>
 				<p>
 					<span>In the last hopeless depth of hell’s dark tomb</span>
 					<br/>

--- a/src/epub/text/postlude.xhtml
+++ b/src/epub/text/postlude.xhtml
@@ -257,7 +257,7 @@
 					<span>I dedicate, my brother, unto you.</span>
 				</p>
 			</article>
-			<section id="ite-missa-est">
+			<section id="ite-missa-est" xml:lang="la">
 				<p>
 					<b>Ite missa est</b>
 				</p>

--- a/src/epub/text/prelude.xhtml
+++ b/src/epub/text/prelude.xhtml
@@ -193,7 +193,7 @@
 			<p>
 				<span>I have drunk out of heavy goblets golden,</span>
 				<br/>
-				<span>As from some hellish tabernaculum</span>
+				<span>As from some hellish <span xml:lang="la">tabernaculum</span></span>
 				<br/>
 				<span>Cannabis, conium;</span>
 				<br/>


### PR DESCRIPTION
Re: `Ite missa est`, it _is_ [listed in M-W's basic online dictionary](https://www.merriam-webster.com/dictionary/ite%2C%20missa%20est) (as `ite, missa est`), but is marked as a "Latin quotation." I think it should still be marked up with `xml:lang="la"`, since it is likely to be read incorrectly by screen readers otherwise.